### PR TITLE
handling via a block parser to be able to strip unwanted wrapping <p>…

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ another paragraph
 Output:
 ```html
 <p>text with <img src="img.png" alt=""></p>
-<p><figure><img src="fig.png" alt=""></figure></p>
+<figure><img src="fig.png" alt=""></figure>
 <p>another paragraph</p>
 ```
 
@@ -32,7 +32,7 @@ $ npm install --save markdown-it-implicit-figures
 var md = require('markdown-it')();
 var implicitFigures = require('markdown-it-implicit-figures');
 
-md.use(implicitFigures);
+md.use(implicitFigures, { dataType: true });
 
 var src = 'text with ![](img.png)\n\n![](fig.png)\n\nanother paragraph';
 var res = md.render(src);
@@ -40,6 +40,11 @@ var res = md.render(src);
 console.log(res);
 ```
 
+## Options
+
+Enabling the `dataType` boolean flag in the options will generate figure tags that
+also declare the data-type being wrapped, e.g.: `<figure data-type="image">`. 
+This can be useful for applying special styling.
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var figure = function (options) {
 
   var dataType = (typeof options.dataType !== 'undefined') ? options.dataType : false;
 
-  return function implicit_figure (state, startLine, endLine, silent) {
+  return function implicit_figure (state, startLine) {
     var content, terminate, i, l, token,
         prevLine = startLine - 1,
         nextLine = startLine + 1,

--- a/index.js
+++ b/index.js
@@ -1,18 +1,63 @@
 'use strict';
 
-module.exports = function implicitFiguresPlugin(md) {
+var figure = function (options) {
 
-  var defaultRender = md.renderer.rules.image;
+  var dataType = (typeof options.dataType !== 'undefined') ? options.dataType : false;
 
-  md.renderer.rules.image = function (tokens, idx, options, env, self) {
-    var token = tokens[idx];
-    var img = defaultRender(tokens, idx, options, env, self);
+  return function implicit_figure (state, startLine, endLine, silent) {
+    var content, terminate, i, l, token,
+        prevLine = startLine - 1,
+        nextLine = startLine + 1,
+        terminatorRules = state.md.block.ruler.getRules('implicit_figure'),
+        endLine = state.lineMax,
+        openTag = dataType ? 'figure data-type="image"' : 'figure';
 
-    if (tokens.length === 1) {
-      // image is alone
-      img = '<figure>'+ img +'</figure>';
+    // jump line-by-line until empty one or EOF
+    for (; nextLine < endLine && !state.isEmpty(nextLine); nextLine++) {
+      // this would be a code block normally, but after paragraph
+      // it's considered a lazy continuation regardless of what's there
+      if (state.sCount[nextLine] - state.blkIndent > 3) { continue; }
+
+      // quirk for blockquotes, this line should already be checked by that rule
+      if (state.sCount[nextLine] < 0) { continue; }
+
+      // Some tags can terminate paragraph without empty line.
+      terminate = false;
+      for (i = 0, l = terminatorRules.length; i < l; i++) {
+        if (terminatorRules[i](state, nextLine, endLine, true)) {
+          terminate = true;
+          break;
+        }
+      }
+      if (terminate) { break; }
     }
 
-    return img;
-  }
+    if (!state.isEmpty(prevLine) || !state.isEmpty(nextLine)) { return false; }
+
+    content = state.getLines(startLine, nextLine, state.blkIndent, false).trim();
+
+    if (content.charCodeAt(0) !== 0x21/* ! */) { return false; }
+    if (content.charCodeAt(1) !== 0x5B/* [ */) { return false; }
+
+    state.line = nextLine;
+
+    token          = state.push('figure_open', openTag, 1);
+    token.map      = [ startLine, state.line ];
+
+    token          = state.push('inline', '', 0);
+    token.content  = content;
+    token.map      = [ startLine, state.line ];
+    token.children = [];
+
+    token          = state.push('figure_close', 'figure', -1);
+
+    return true;
+  };
+};
+
+module.exports = function implicitFiguresPlugin(md, options) {
+
+  options = options || {};
+
+  md.block.ruler.before('paragraph', 'implicit_figure', figure(options), { alt: ['paragraph'] });
 };

--- a/test.js
+++ b/test.js
@@ -11,7 +11,7 @@ describe('markdown-it-implicit-figures', function() {
 
   it('should add <figure> when image is by itself in a paragraph', function () {
     var src = 'text with ![](img.png)\n\n![](fig.png)\n\nanother paragraph';
-    var expected = '<p>text with <img src="img.png" alt=""></p>\n<p><figure><img src="fig.png" alt=""></figure></p>\n<p>another paragraph</p>\n';
+    var expected = '<p>text with <img src="img.png" alt=""></p>\n<figure><img src="fig.png" alt=""></figure>\n<p>another paragraph</p>\n';
     var res = md.render(src);
     assert.equal(res, expected);
   });


### PR DESCRIPTION
Biggish change to the approach here, but it's the only way I could find to get a handle on the wrapping `<p>` tags which, IMO, shouldn't be surrounding a `<figure>` (see #1 ).

Also added an option for declaring a `data-type` attribute on the figure tag.

Essentially this is copy/pasted logic from the markdown-it paragraph parser, which some small changes to ensure the image tag exists and is isolated.
