### PR TITLE
implicit figcaption

### DIFF
--- a/demo.js
+++ b/demo.js
@@ -2,9 +2,9 @@
 var md = require('markdown-it')();
 var implicitFigures = require('./');
 
-md.use(implicitFigures);
+md.use(implicitFigures, { dataType: true, figcaption: true });
 
-var src = 'text with ![](img.png)\n\n![](fig.png)\n\nanother paragraph';
+var src = 'text with ![](img.png)\n\n![Will become caption.](fig.png "Foo bar")\n\nanother paragraph';
 var res = md.render(src);
 
 console.log(res);

--- a/index.js
+++ b/index.js
@@ -31,6 +31,21 @@ module.exports = function implicitFiguresPlugin(md, options) {
       if (options.dataType == true) {
         state.tokens[i - 1].attrPush(['data-type', 'image']);
       }
+
+      if (options.figcaption == true) {
+        var image = token.children[0];
+        if (image.children && image.children.length) {
+          token.children.push(
+            new state.Token('figcaption_open', 'figcaption', 1)
+            );
+          token.children.push(
+            md.utils.assign({}, image.children[0])
+            );
+          token.children.push(
+            new state.Token('figcaption_close', 'figcaption', -1)
+            );
+        }
+      }
     }
   }
 

--- a/test.js
+++ b/test.js
@@ -25,4 +25,12 @@ describe('markdown-it-implicit-figures', function() {
     assert.equal(res, expected);
   });
 
+  it('should add convert alt text into a figcaption when opts.figcaption is set', function () {
+    md = Md().use(implicitFigures, { figcaption: true });
+    var src = 'text with ![](img.png)\n\n![This is a caption](fig.png)\n\nanother paragraph';
+    var expected = '<p>text with <img src="img.png" alt=""></p>\n<figure><img src="fig.png" alt="This is a caption"><figcaption>This is a caption</figcaption></figure>\n<p>another paragraph</p>\n';
+    var res = md.render(src);
+    assert.equal(res, expected);
+  });
+
 });


### PR DESCRIPTION
Similar to the pandoc version, `[alt]` text (the stuff in the brackets) will get pushed into a `<figcaption>` tag.

I can imagine a config option / variant to instead stick the `title` text in there. If that's desirable maybe a new issue can be opened.

Resolves #2 
