### PR TITLE
Add feature to force rendering an image as img tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,24 @@ Render images occurring by itself in a paragraph as `<figure><img ...></figure>`
 
 Example input:
 ```md
-text with ![](img.png)
-
 ![](fig.png)
 
-another paragraph
+![Alt text](fig.png)
+
+paragraph with inline ![](img.png)
+
+![||](fig.png)
 ```
 
 Output:
 ```html
-<p>text with <img src="img.png" alt=""></p>
 <figure><img src="fig.png" alt=""></figure>
-<p>another paragraph</p>
+
+<figure><img src="fig.png" alt="Alt text"><figcaption>Alt text</figcaption></figure>
+
+<p>paragraph with inline <img src="img.png" alt=""></p>
+
+<p><img src="img.png" alt=""></p>
 ```
 
 
@@ -34,7 +40,8 @@ var implicitFigures = require('markdown-it-implicit-figures');
 
 md.use(implicitFigures, {
   dataType: false,  // <figure data-type="image">, default: false
-  figcaption: false  // <figcaption>alternative text</figcaption>, default: false
+  figcaption: false,  // <figcaption>alternative text</figcaption>, default: false
+  forceImg: "|"  // default: "||"
 });
 
 var src = 'text with ![](img.png)\n\n![](fig.png)\n\nanother paragraph';
@@ -59,7 +66,7 @@ console.log(res);
     <figcaption>text</figcaption>
   </figure>
   ```
-
+- `forceImg`: Searches for a string inside the markdown `alt` text field, if found forces image to render inside an `img` tag. Defaults to `"||"`
 
 
 ## License

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 module.exports = function implicitFiguresPlugin(md, options) {
   options = options || {};
+  options.forceImg = "||";
 
   function implicitFigures(state) {
     // do not process first and last token
@@ -22,6 +23,20 @@ module.exports = function implicitFiguresPlugin(md, options) {
       // We have inline token containing an image only.
       // Previous token is paragraph open.
       // Next token is paragraph close.
+      // Now let's scan the image alt text for forceImg indicator.
+      if (token.children[0].content.indexOf(options.forceImg) !== -1) {
+        var captions = token.children[0].content.split(options.forceImg);
+        // Remove blank strings after splitting text at forceImg markers
+        for (var y = 0; y < captions.length; y++) {
+          if (captions[y].length === 0) {
+            captions.splice(y, 1);
+          }
+        }
+        // Then convert leftover strings into sentences.
+        token.children[0].children[0].content = captions.join('. ');
+        continue;
+      }
+
       // Lets replace the paragraph tokens with figure tokens.
       state.tokens[i - 1].type = 'figure_open';
       state.tokens[i - 1].tag = 'figure';

--- a/test.js
+++ b/test.js
@@ -16,7 +16,6 @@ describe('markdown-it-implicit-figures', function() {
     assert.equal(res, expected);
   });
 
-
   it('should add data-type=image to figures when opts.dataType is set', function () {
     md = Md().use(implicitFigures, { dataType: true });
     var src = '![](fig.png)\n';
@@ -29,6 +28,29 @@ describe('markdown-it-implicit-figures', function() {
     md = Md().use(implicitFigures, { figcaption: true });
     var src = '![This is a caption](fig.png)';
     var expected = '<figure><img src="fig.png" alt="This is a caption"><figcaption>This is a caption</figcaption></figure>\n';
+    var res = md.render(src);
+    assert.equal(res, expected);
+  });
+
+  it('should not add <figure> when image is inside a paragraph with text', function () {
+    var src = 'text with ![](img.png)\n\nAnother paragraph';
+    var expected = '<p>text with <img src="img.png" alt=""></p>\n<p>Another paragraph</p>\n';
+    var res = md.render(src);
+    assert.equal(res, expected);
+  });
+
+  it('should not add <figure> when image has forceImage indicator', function () {
+    md = Md().use(implicitFigures);
+    var src = '![||](fig.png)\n';
+    var expected = '<p><img src="fig.png" alt=""></p>\n';
+    var res = md.render(src);
+    assert.equal(res, expected);
+  });
+
+  it('should convert alt text into a figcaption', function () {
+    md = Md().use(implicitFigures, { figcaption: true });
+    var src = '![This is a caption and figcaption](fig.png)';
+    var expected = '<figure><img src="fig.png" alt="This is a caption and figcaption"><figcaption>This is a caption and figcaption</figcaption></figure>\n';
     var res = md.render(src);
     assert.equal(res, expected);
   });


### PR DESCRIPTION
Due to layout reasons I needed the flexibility to control how images are rendered, either as figures or inline inside paragraphs.
As this should not break current functionality I thought I'd propose a PR.

It adds a `forceImg` option which scans for a string (`||` by default) inside the markdown alt text and renders the image inside paragraph if matched.

For example:

``` md
![Caption||](fig.png)
```

becomes

``` html
<p><img src="fig.png" alt="Caption"><p>
```

As I'm writing this I realize I could also revise it to make the function optional, similar to the `figcaption` setting.
