### PR TITLE
Add option for tabindex attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ console.log(res);
     <figcaption>text</figcaption>
   </figure>
   ```
+- `tabindex`: Set `tabindex` to `true` to add a `tabindex` property to each
+  figure, beginning at `tabindex="1"` and incrementing for each figure
+  encountered. Could be used with [this css-trick](https://css-tricks.com/expanding-images-html5/)
 
 
 

--- a/index.js
+++ b/index.js
@@ -3,9 +3,10 @@
 module.exports = function implicitFiguresPlugin(md, options) {
   options = options || {};
 
-  var tabIndex = 1;
-
   function implicitFigures(state) {
+    // reset tabIndex on md.render()
+    var tabIndex = 1;
+
     // do not process first and last token
     for (var i=1, l=state.tokens.length; i < (l - 1); ++i) {
       var token = state.tokens[i];

--- a/index.js
+++ b/index.js
@@ -3,6 +3,8 @@
 module.exports = function implicitFiguresPlugin(md, options) {
   options = options || {};
 
+  var tabIndex = 1;
+
   function implicitFigures(state) {
     // do not process first and last token
     for (var i=1, l=state.tokens.length; i < (l - 1); ++i) {
@@ -53,6 +55,13 @@ module.exports = function implicitFiguresPlugin(md, options) {
             new state.Token('figcaption_close', 'figcaption', -1)
             );
         }
+      }
+
+      if (options.tabindex == true) {
+        // add a tabindex property
+        // you could use this with css-tricks.com/expanding-images-html5
+        state.tokens[i - 1].attrPush(['tabindex', tabIndex]);
+        tabIndex++;
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-it-implicit-figures",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "Render images occurring by itself in a paragraph as `<figure><img ...></figure>`, similar to pandoc's implicit_figures",
   "license": "MIT",
   "repository": "arve0/markdown-it-implicit-figures",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-it-implicit-figures",
-  "version": "0.4.0",
+  "version": "0.3.2",
   "description": "Render images occurring by itself in a paragraph as `<figure><img ...></figure>`, similar to pandoc's implicit_figures",
   "license": "MIT",
   "repository": "arve0/markdown-it-implicit-figures",

--- a/test.js
+++ b/test.js
@@ -40,6 +40,14 @@ describe('markdown-it-implicit-figures', function() {
     assert.equal(res, expected);
   });
 
+  it('should add incremental tabindex to figures when opts.tabindex is set', function () {
+    md = Md().use(implicitFigures, { tabindex: true });
+    var src = '![](fig.png)\n\n![](fig2.png)';
+    var expected = '<figure tabindex="1"><img src="fig.png" alt=""></figure>\n<figure tabindex="2"><img src="fig2.png" alt=""></figure>\n';
+    var res = md.render(src);
+    assert.equal(res, expected);
+  });
+
   it('should not make figures of paragraphs with text and inline code', function () {
     var src = 'Text.\n\nAnd `code`.';
     var expected = '<p>Text.</p>\n<p>And <code>code</code>.</p>\n';

--- a/test.js
+++ b/test.js
@@ -48,6 +48,17 @@ describe('markdown-it-implicit-figures', function() {
     assert.equal(res, expected);
   });
 
+  it('should reset tabindex on each md.render()', function () {
+    md = Md().use(implicitFigures, { tabindex: true });
+    var src = '![](fig.png)\n\n![](fig2.png)';
+    var expected = '<figure tabindex="1"><img src="fig.png" alt=""></figure>\n<figure tabindex="2"><img src="fig2.png" alt=""></figure>\n';
+    var res = md.render(src);
+    assert.equal(res, expected);
+    // render again, should produce same if resetting
+    res = md.render(src);
+    assert.equal(res, expected);
+  });
+
   it('should not make figures of paragraphs with text and inline code', function () {
     var src = 'Text.\n\nAnd `code`.';
     var expected = '<p>Text.</p>\n<p>And <code>code</code>.</p>\n';


### PR DESCRIPTION
This was useful for a personal project, inspired by [this css-trick](https://css-tricks.com/expanding-images-html5/). If you don't think it's appropriate for the master branch here, I'm happy to close this request 🙂.