### PR TITLE
Link to unlinked image with  { link: true }

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ var implicitFigures = require('markdown-it-implicit-figures');
 
 md.use(implicitFigures, {
   dataType: false,  // <figure data-type="image">, default: false
-  figcaption: false  // <figcaption>alternative text</figcaption>, default: false
+  figcaption: false,  // <figcaption>alternative text</figcaption>, default: false
+  tabindex: false, // <figure tabindex="1+n">..., default: false
+  link: false // <a href="img.png"><img src="img.png"></a>, default: false
 });
 
 var src = 'text with ![](img.png)\n\n![](fig.png)\n\nanother paragraph';
@@ -66,7 +68,7 @@ console.log(res);
   figure, beginning at `tabindex="1"` and incrementing for each figure
   encountered. Could be used with [this css-trick](https://css-tricks.com/expanding-images-html5/),
   which expands figures upon mouse-over.
-
+- `link`: Put a link around the image if there is none yet.
 
 
 ## License

--- a/index.js
+++ b/index.js
@@ -40,10 +40,22 @@ module.exports = function implicitFiguresPlugin(md, options) {
       if (options.dataType == true) {
         state.tokens[i - 1].attrPush(['data-type', 'image']);
       }
+      var image;
+
+      if (options.link == true && token.children.length === 1) {
+        image = token.children[0];
+        token.children.unshift(
+          new state.Token('link_open', 'a', 1)
+        );
+        token.children[0].attrPush(['href', image.attrGet('src')]);
+        token.children.push(
+          new state.Token('link_close', 'a', -1)
+        );
+      }
 
       if (options.figcaption == true) {
         //for linked images, image is one off
-        var image = (token.children.length === 1) ? token.children[0] : token.children[1];
+        image = image || ((token.children.length === 1) ? token.children[0] : token.children[1]);
 
         if (image.children && image.children.length) {
           token.children.push(

--- a/test.js
+++ b/test.js
@@ -108,8 +108,8 @@ describe('markdown-it-implicit-figures', function() {
 
   it('should leave the image inside a link (and not create an extra one) if it is already linked', function () {
     md = Md().use(implicitFigures, { link: true });
-    var src = '[![www.google.com](fig.png)](fig.png)';
-    var expected = '<figure><a href="fig.png"><img src="fig.png" alt="www.google.com"></a></figure>\n';
+    var src = '[![www.google.com](fig.png)](link.html)';
+    var expected = '<figure><a href="link.html"><img src="fig.png" alt="www.google.com"></a></figure>\n';
     var res = md.render(src);
     assert.equal(res, expected);
   });

--- a/test.js
+++ b/test.js
@@ -89,4 +89,29 @@ describe('markdown-it-implicit-figures', function() {
     var res = md.render(src);
     assert.equal(res, expected);
   });
+
+  it('should put the image inside a link to the image if it is not yet linked', function () {
+    md = Md().use(implicitFigures, { link: true });
+    var src = '![www.google.com](fig.png)';
+    var expected = '<figure><a href="fig.png"><img src="fig.png" alt="www.google.com"></a></figure>\n';
+    var res = md.render(src);
+    assert.equal(res, expected);
+  });
+
+  it('should not mess up figcaption when linking', function () {
+    md = Md().use(implicitFigures, { figcaption: true, link: true });
+    var src = '![www.google.com](fig.png)';
+    var expected = '<figure><a href="fig.png"><img src="fig.png" alt="www.google.com"></a><figcaption>www.google.com</figcaption></figure>\n';
+    var res = md.render(src);
+    assert.equal(res, expected);
+  });
+
+  it('should leave the image inside a link (and not create an extra one) if it is already linked', function () {
+    md = Md().use(implicitFigures, { link: true });
+    var src = '[![www.google.com](fig.png)](fig.png)';
+    var expected = '<figure><a href="fig.png"><img src="fig.png" alt="www.google.com"></a></figure>\n';
+    var res = md.render(src);
+    assert.equal(res, expected);
+  });
+
 });


### PR DESCRIPTION
Links images so users can easily view the image at their full size if needed (without JS), but keeps the markdown source clean, readable and the writing less error-prone.

Also, add tabindex to README example