### PR TITLE
Bugfix: figcaption would be set correctly for multiple images

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,8 +54,8 @@ module.exports = function implicitFiguresPlugin(md, options) {
       }
 
       if (options.figcaption == true) {
-        //for linked images, image is one off
-        image = image || ((token.children.length === 1) ? token.children[0] : token.children[1]);
+        // for linked images, image is one off
+        image = token.children.length === 1 ? token.children[0] : token.children[1];
 
         if (image.children && image.children.length) {
           token.children.push(

--- a/test.js
+++ b/test.js
@@ -41,6 +41,14 @@ describe('markdown-it-implicit-figures', function() {
     assert.equal(res, expected);
   });
 
+  it('should convert alt text for each image into a figcaption when opts.figcaption is set', function () {
+    md = Md().use(implicitFigures, { figcaption: true });
+    var src = '![caption 1](fig.png)\n\n![caption 2](fig2.png)';
+    var expected = '<figure><img src="fig.png" alt="caption 1"><figcaption>caption 1</figcaption></figure>\n<figure><img src="fig2.png" alt="caption 2"><figcaption>caption 2</figcaption></figure>\n'
+    var res = md.render(src);
+    assert.equal(res, expected);
+  });
+
   it('should add incremental tabindex to figures when opts.tabindex is set', function () {
     md = Md().use(implicitFigures, { tabindex: true });
     var src = '![](fig.png)\n\n![](fig2.png)';


### PR DESCRIPTION
Fixes: https://github.com/arve0/markdown-it-implicit-figures/issues/26

The `image` variable was cached, so it would always get the first image of the tokens loop, hence the figcaption would be the first image's alt text, ignoring remaining ones.

This PR removes the variable caching. Tests all passed locally.

---

The spec I added felt a bit redundant, let me know your thoughts whether we remove it or merge it to the [above one](https://github.com/kinopyo/markdown-it-implicit-figures/blob/78d940d68ea4458d75b9174f22647bbffc5f263e/test.js#L44). 🙏 