### PR TITLE
Add lazy loading option for images

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ md.use(implicitFigures, {
   dataType: false,  // <figure data-type="image">, default: false
   figcaption: false,  // <figcaption>alternative text</figcaption>, default: false
   tabindex: false, // <figure tabindex="1+n">..., default: false
+  lazyLoading: false, // <img loading="lazy" ...>, default: false
   link: false // <a href="img.png"><img src="img.png"></a>, default: false
 });
 
@@ -68,6 +69,7 @@ console.log(res);
   figure, beginning at `tabindex="1"` and incrementing for each figure
   encountered. Could be used with [this css-trick](https://css-tricks.com/expanding-images-html5/),
   which expands figures upon mouse-over.
+- `lazyLoading`: Set `lazyLoading` to `true` to add `loading="lazy"` to image element.
 - `link`: Put a link around the image if there is none yet.
 - `copyAttrs`: Copy attributes matching (RegExp or string) `copyAttrs` to `figure` element.
 

--- a/index.js
+++ b/index.js
@@ -81,6 +81,10 @@ module.exports = function implicitFiguresPlugin(md, options) {
         state.tokens[i - 1].attrPush(['tabindex', tabIndex]);
         tabIndex++;
       }
+
+      if (options.lazyLoading == true) {
+        image.attrPush(['loading', 'lazy']);
+      }
     }
   }
   md.core.ruler.before('linkify', 'implicit_figures', implicitFigures);

--- a/test.js
+++ b/test.js
@@ -68,6 +68,14 @@ describe('markdown-it-implicit-figures', function() {
     assert.equal(res, expected);
   });
 
+  it('should add loading lazy attribute to image when opts.lazyLoading is set', function () {
+    md = Md().use(implicitFigures, { lazyLoading: true });
+    var src = '![](fig.png)';
+    var expected = '<figure><img src="fig.png" alt="" loading="lazy"></figure>\n';
+    var res = md.render(src);
+    assert.equal(res, expected);
+  });
+
   it('should not make figures of paragraphs with text and inline code', function () {
     var src = 'Text.\n\nAnd `code`.';
     var expected = '<p>Text.</p>\n<p>And <code>code</code>.</p>\n';


### PR DESCRIPTION
Config:
```js
md.use(implicitFigures, {
  figcaption: true,
  lazyLoading: true
});

var src = '![](fig.png)';
md.render(src);
```
Result:
```html
<figure><img src="fig.png" alt="" loading="lazy"></figure>
```