### PR TITLE
Add support for figcaption "title" option and keepAlt flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,10 @@ var implicitFigures = require('markdown-it-implicit-figures');
 md.use(implicitFigures, {
   dataType: false,  // <figure data-type="image">, default: false
   figcaption: false,  // <figcaption>alternative text</figcaption>, default: false
-  tabindex: false, // <figure tabindex="1+n">..., default: false
+  keepAlt: false // <img alt="alt text" .../><figcaption>alt text</figcaption>, default: false
   lazyLoading: false, // <img loading="lazy" ...>, default: false
   link: false // <a href="img.png"><img src="img.png"></a>, default: false
+  tabindex: false, // <figure tabindex="1+n">..., default: false
 });
 
 var src = 'text with ![](img.png)\n\n![](fig.png)\n\nanother paragraph';
@@ -56,12 +57,29 @@ console.log(res);
 - `dataType`: Set `dataType` to `true` to declare the data-type being wrapped,
   e.g.: `<figure data-type="image">`. This can be useful for applying special
   styling for different kind of figures.
-- `figcaption`: Set `figcaption` to `true` to put the alternative text in a
-  `<figcaption>`-block after the image. E.g.: `![text](img.png)` renders to
+- `figcaption`: Set `figcaption` to `true` or `alt` to put the alternative text
+  in a `<figcaption>`-block after the image. E.g.: `![text](img.png)` renders to
 
   ```html
   <figure>
     <img src="img.png" alt="">
+    <figcaption>text</figcaption>
+  </figure>
+  ```
+  - Set `figcaption` to `title` to put the title text in a `<figcaption>`-block
+    after the image. E.g.: `![text](img.png "title")` renders to
+    ```html
+    <figure>
+      <img src="img.png" alt="text">
+      <figcaption>title</figcaption>
+    </figure>
+    ```
+- `keepAlt`: Set `keepAlt` to `true` to prevent it from being cleared when turned
+  into a `figcaption`, E.g.: `![text](img.png)` renders to
+
+  ```html
+  <figure>
+    <img src="img.png" alt="text">
     <figcaption>text</figcaption>
   </figure>
   ```

--- a/test.js
+++ b/test.js
@@ -17,9 +17,9 @@ describe('markdown-it-implicit-figures', function() {
     assert.equal(res, expected);
   });
 
-  it('should add <figure> when image is by itself in a paragraph and preceeded by a standalone link', function () {
-    md = Md().use(implicitFigures, { dataType: true, figcaption: true });
-    var src = '[![Caption](fig.png)](http://example.com)';
+  it('should add <figure> when image is by itself in a paragraph and preceded by a standalone link', function () {
+    md = Md().use(implicitFigures, { dataType: true, figcaption: 'title' });
+    var src = '[![](fig.png "Caption")](http://example.com)';
     var expected = '<figure data-type="image"><a href="http://example.com"><img src="fig.png" alt=""></a><figcaption>Caption</figcaption></figure>\n';
     var res = md.render(src);
     assert.equal(res, expected);
@@ -33,18 +33,50 @@ describe('markdown-it-implicit-figures', function() {
     assert.equal(res, expected);
   });
 
-  it('should add convert alt text into a figcaption when opts.figcaption is set', function () {
+  it('should convert title text into a figcaption when opts.figcaption is set to "title"', function () {
+    md = Md().use(implicitFigures, { figcaption: 'title' });
+    var src = '![This is an alt](fig.png "This is a caption")';
+    var expected = '<figure><img src="fig.png" alt="This is an alt"><figcaption>This is a caption</figcaption></figure>\n';
+    var res = md.render(src);
+    assert.equal(res, expected);
+  });
+
+  it('should convert alt text into a figcaption when opts.figcaption is set', function () {
     md = Md().use(implicitFigures, { figcaption: true });
-    var src = '![This is a caption](fig.png)';
-    var expected = '<figure><img src="fig.png" alt=""><figcaption>This is a caption</figcaption></figure>\n';
+    var src = '![This is an alt](fig.png "This is a caption")';
+    var expected = '<figure><img src="fig.png" alt="" title="This is a caption"><figcaption>This is an alt</figcaption></figure>\n';
+    var res = md.render(src);
+    assert.equal(res, expected);
+  });
+
+  it('should convert alt text into a figcaption when opts.figcaption is set and keep it when keepAlt is set', function () {
+    md = Md().use(implicitFigures, { figcaption: true, keepAlt: true });
+    var src = '![This is an alt](fig.png "This is a caption")';
+    var expected = '<figure><img src="fig.png" alt="This is an alt" title="This is a caption"><figcaption>This is an alt</figcaption></figure>\n';
+    var res = md.render(src);
+    assert.equal(res, expected);
+  });
+
+  it('should convert title text for each image into a figcaption when opts.figcaption is set to "title"', function () {
+    md = Md().use(implicitFigures, { figcaption: 'title' });
+    var src = '![alt 1](fig.png "caption 1")\n\n![alt 2](fig2.png "caption 2")';
+    var expected = '<figure><img src="fig.png" alt="alt 1"><figcaption>caption 1</figcaption></figure>\n<figure><img src="fig2.png" alt="alt 2"><figcaption>caption 2</figcaption></figure>\n'
     var res = md.render(src);
     assert.equal(res, expected);
   });
 
   it('should convert alt text for each image into a figcaption when opts.figcaption is set', function () {
     md = Md().use(implicitFigures, { figcaption: true });
-    var src = '![caption 1](fig.png)\n\n![caption 2](fig2.png)';
-    var expected = '<figure><img src="fig.png" alt=""><figcaption>caption 1</figcaption></figure>\n<figure><img src="fig2.png" alt=""><figcaption>caption 2</figcaption></figure>\n'
+    var src = '![alt 1](fig.png "caption 1")\n\n![alt 2](fig2.png "caption 2")';
+    var expected = '<figure><img src="fig.png" alt="" title="caption 1"><figcaption>alt 1</figcaption></figure>\n<figure><img src="fig2.png" alt="" title="caption 2"><figcaption>alt 2</figcaption></figure>\n'
+    var res = md.render(src);
+    assert.equal(res, expected);
+  });
+
+  it('should convert alt text for each image into a figcaption when opts.figcaption is set and keepAlt is set', function () {
+    md = Md().use(implicitFigures, { figcaption: true, keepAlt: true });
+    var src = '![alt 1](fig.png "caption 1")\n\n![alt 2](fig2.png "caption 2")';
+    var expected = '<figure><img src="fig.png" alt="alt 1" title="caption 1"><figcaption>alt 1</figcaption></figure>\n<figure><img src="fig2.png" alt="alt 2" title="caption 2"><figcaption>alt 2</figcaption></figure>\n'
     var res = md.render(src);
     assert.equal(res, expected);
   });
@@ -90,10 +122,27 @@ describe('markdown-it-implicit-figures', function() {
     assert.equal(res, expected);
   });
 
-  it('should linkify captions', function () {
+  it('should linkify captions when figcaption is set to "title"', function () {
+    md = Md({ linkify: true }).use(implicitFigures, { figcaption: 'title' });
+    var src = '![](fig.png "www.google.com")';
+    var expected = '<figure><img src="fig.png" alt=""><figcaption><a href="http://www.google.com">www.google.com</a></figcaption></figure>\n';
+    var res = md.render(src);
+    assert.equal(res, expected);
+  });
+
+
+  it('should linkify captions when figcaption is on', function () {
     md = Md({ linkify: true }).use(implicitFigures, { figcaption: true });
     var src = '![www.google.com](fig.png)';
     var expected = '<figure><img src="fig.png" alt=""><figcaption><a href="http://www.google.com">www.google.com</a></figcaption></figure>\n';
+    var res = md.render(src);
+    assert.equal(res, expected);
+  });
+
+  it('should linkify captions when figcaption is on and keepAlt is set', function () {
+    md = Md({ linkify: true }).use(implicitFigures, { figcaption: true, keepAlt: true });
+    var src = '![www.google.com](fig.png)';
+    var expected = '<figure><img src="fig.png" alt="www.google.com"><figcaption><a href="http://www.google.com">www.google.com</a></figcaption></figure>\n';
     var res = md.render(src);
     assert.equal(res, expected);
   });
@@ -114,10 +163,27 @@ describe('markdown-it-implicit-figures', function() {
     assert.equal(res, expected);
   });
 
+  it('should not mess up figcaption when linking and figcaption is set to "title"', function () {
+    md = Md().use(implicitFigures, { figcaption: 'title', link: true });
+    var src = '![](fig.png "www.google.com")';
+    var expected = '<figure><a href="fig.png"><img src="fig.png" alt=""></a><figcaption>www.google.com</figcaption></figure>\n';
+    var res = md.render(src);
+    assert.equal(res, expected);
+  });
+
   it('should not mess up figcaption when linking', function () {
-    md = Md().use(implicitFigures, { figcaption: true, link: true });
+    md = Md().use(implicitFigures, { figcaption: 'alt', link: true });
     var src = '![www.google.com](fig.png)';
     var expected = '<figure><a href="fig.png"><img src="fig.png" alt=""></a><figcaption>www.google.com</figcaption></figure>\n';
+    var res = md.render(src);
+    assert.equal(res, expected);
+  });
+
+
+  it('should not mess up figcaption when linking and keepAlt is set', function () {
+    md = Md().use(implicitFigures, { figcaption: 'alt', link: true, keepAlt: true });
+    var src = '![www.google.com](fig.png)';
+    var expected = '<figure><a href="fig.png"><img src="fig.png" alt="www.google.com"></a><figcaption>www.google.com</figcaption></figure>\n';
     var res = md.render(src);
     assert.equal(res, expected);
   });
@@ -130,9 +196,9 @@ describe('markdown-it-implicit-figures', function() {
     assert.equal(res, expected);
   });
 
-  it('should keep structured markup inside caption (event if not supported in "alt" attribute)', function () {
-    md = Md().use(implicitFigures, { figcaption: true });
-    var src = '![Image from [source](to)](fig.png)';
+  it('should keep structured markup inside caption (even if not supported in "alt" attribute)', function () {
+    md = Md().use(implicitFigures, { figcaption: 'title' });
+    var src = '![](fig.png "Image from [source](to)")';
     var expected = '<figure><img src="fig.png" alt=""><figcaption>Image from <a href="to">source</a></figcaption></figure>\n';
     var res = md.render(src);
     assert.equal(res, expected);


### PR DESCRIPTION
Good day!

First off, thank you for the work that's been put into this excellent library.

This PR includes everything from https://github.com/arve0/markdown-it-implicit-figures/pull/40, building off of Antonio-Laguna's excellent work, while also incorporating all of @arve0's suggestions and keeping backwards compatibility.

**New Features**

- Updates `figcaption` flag to take one of the strings `alt` or `title`, in addition to a `boolean` value (as now).
  - The `title` option provides the feature that Antonio-Laguna's code introduced, creating the `figcaption` from the image's `title` attribute rather than the `alt` attribute.
  - The `alt` option is the same as `true`, and provides the existing behavior (creating the `figcaption` from the image's `alt` attribute).

- Adds new `keepAlt` flag which takes a boolean value (defaults to false).
  - If set to `true`, and `figcaption` is set to `true` or `alt`, this keeps the `alt` attribute text in the `img` tag, rather than blanking it out (the existing / default behavior).

I also 8 new tests (and updated some existing ones) to cover the changes, and updated the README accordingly.

Fixes [#20](https://github.com/arve0/markdown-it-implicit-figures/issues/20) & [#39](https://github.com/arve0/markdown-it-implicit-figures/issues/39).

Please let me know if there's any changes I need to make. Thanks for your time!